### PR TITLE
Fix tcp_syn probe output fields

### DIFF
--- a/libzmap/probes/icmp_echo_time.py
+++ b/libzmap/probes/icmp_echo_time.py
@@ -1,8 +1,8 @@
 class IcmpEchoTime(object):
     output_fields = (
-        'saddr', 'saddr_raw', 'daddr', 'daddr_raw', 'ipid', 'ttl', 'type', 'code', 'icmp_id', 'seq',
-        'sent_timestamp_ts', 'sent_timestamp_us', 'dst_raw', 'classification', 'success', 'repeat',
-        'cooldown', 'timestamp_str', 'timestamp_ts', 'timestamp_us'
+        'saddr', 'saddr-raw', 'daddr', 'daddr-raw', 'ipid', 'ttl', 'type', 'code', 'icmp-id', 'seq',
+        'sent-timestamp-ts', 'sent-timestamp-us', 'dst-raw', 'classification', 'success', 'repeat',
+        'cooldown', 'timestamp-str', 'timestamp-ts', 'timestamp-us'
     )
 
     def __init__(self, saddr, saddr_raw, daddr, daddr_raw, ipid, ttl, _type, code, icmp_id, seq, sent_timestamp_ts,

--- a/libzmap/probes/tcp_syn.py
+++ b/libzmap/probes/tcp_syn.py
@@ -1,7 +1,7 @@
 class TcpSyn(object):
 
     output_fields = (
-        'saddr-raw', 'daddr', 'daddr-raw', 'ipid', 'ttl', 'sport', 'dport', 'seqnum', 'acknum', 'window',
+        'saddr', 'saddr-raw', 'daddr', 'daddr-raw', 'ipid', 'ttl', 'sport', 'dport', 'seqnum', 'acknum', 'window',
         'classification', 'success', 'repeat', 'cooldown', 'timestamp-str', 'timestamp-ts', 'timestamp-us'
     )
 

--- a/libzmap/probes/udp.py
+++ b/libzmap/probes/udp.py
@@ -1,9 +1,9 @@
 class Udp(object):
 
     output_fields = (
-        'saddr', 'saddr_raw', 'daddr', 'daddr_raw', 'ipid', 'ttl', 'classification', 'success', 'sport', 'dport',
+        'saddr', 'saddr-raw', 'daddr', 'daddr-raw', 'ipid', 'ttl', 'classification', 'success', 'sport', 'dport',
         'icmp_responder', 'icmp_type', 'icmp_code', 'icmp_unreach_str', 'udp_pkt_size', 'data', 'repeat', 'cooldown',
-        'timestamp_str', 'timestamp_ts', 'timestamp_us'
+        'timestamp-str', 'timestamp-ts', 'timestamp-us'
     )
 
     def __init__(self, saddr, saddr_raw, daddr, daddr_raw, ipid, ttl, classification, success, sport, dport,

--- a/libzmap/probes/upnp.py
+++ b/libzmap/probes/upnp.py
@@ -1,9 +1,9 @@
 class Upnp(object):
     output_fields = (
-        'saddr', 'saddr_raw', 'daddr', 'daddr_raw', 'ipid', 'ttl', 'classification', 'success', 'server', 'location',
+        'saddr', 'saddr-raw', 'daddr', 'daddr-raw', 'ipid', 'ttl', 'classification', 'success', 'server', 'location',
         'usn', 'st', 'ext', 'cache_control', 'x_user_agent', 'agent', 'date', 'sport', 'dport', 'icmp_responder',
-        'icmp_type', 'icmp_code', 'icmp_unreach_str', 'data', 'repeat', 'cooldown', 'timestamp_str', 'timestamp_ts',
-        'timestamp_us'
+        'icmp_type', 'icmp_code', 'icmp_unreach_str', 'data', 'repeat', 'cooldown', 'timestamp-str', 'timestamp-ts',
+        'timestamp-us'
     )
 
     def __init__(self, saddr, saddr_raw, daddr, daddr_raw, ipid, ttl, classification, success, server, location, usn,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 install_requires = []
 
 setup(name="libzmap",
-      version="v0.0.2",
+      version="v0.0.3",
       description="zmap binding for python",
       author="gushitong",
       author_email="gushitong@gmail.com",


### PR DESCRIPTION
The output field 'saddr' is missing in the output_fields tuple. 